### PR TITLE
Update rewind-to-commit.md

### DIFF
--- a/snippets/rewind-to-commit.md
+++ b/snippets/rewind-to-commit.md
@@ -16,7 +16,7 @@ git reset [--hard] <commit>
 ```
 
 ```shell
-git reset --hard 3050fc0d3
+git reset 3050fc0d3
 # Rewinds back to `3050fc0d3` but keeps changes in the working directory
 
 git reset --hard c0d30f305


### PR DESCRIPTION
Rewinds back to `3050fc0d3` but keeps changes in the working directory  --> it doesn't need `--hard`